### PR TITLE
✨ Add tada to party popper

### DIFF
--- a/emoji-selector@maestroschan.fr/data/emojisKeywords.js
+++ b/emoji-selector@maestroschan.fr/data/emojisKeywords.js
@@ -807,7 +807,7 @@ var ALL_KEYWORDS = [
 		["sparkler", "party"],
 		["sparkles", "party", "feature"],
 		["balloon", "party"],
-		["party popper", "party", "initial"],
+		["party popper", "party", "initial", "tada"],
 		["confetti ball", "party"],
 		["tanabata tree", "bamboo"],
 		["pine decoration", "bamboo", "kadomatsu"],


### PR DESCRIPTION
✨ Add `tada` keyword to "party popper" emoji keywords.

Just because `tada` is used by GitHub, Slack, and others for the "party popper" emoji.

---

BTW, thanks for this extension! It's awesome! :sparkles: :rocket: 