### PR TITLE
Add option to remove arrow on tray icon

### DIFF
--- a/emoji-selector@maestroschan.fr/extension.js
+++ b/emoji-selector@maestroschan.fr/extension.js
@@ -224,7 +224,9 @@ class EmojisMenu {
 			style_class: 'system-status-icon emotes-icon'
 		});
 		box.add_child(icon);
-		box.add_child(PopupMenu.arrowIcon(St.Side.BOTTOM));
+		if ( SETTINGS.get_boolean('remove-arrow') != true ){
+			box.add_child(PopupMenu.arrowIcon(St.Side.BOTTOM));
+		}
 		this._permanentItems = 0;
 		this._activeCat = -1;
 

--- a/emoji-selector@maestroschan.fr/prefs.js
+++ b/emoji-selector@maestroschan.fr/prefs.js
@@ -159,6 +159,23 @@ const EmojiSelectorSettingsWidget = new GObject.Class({
 		SETTINGS.connect('changed::always-show', () => {
 			alwaysShowSwitch.set_state(SETTINGS.get_boolean('always-show'));
 		});
+
+		//----------------------------------------------------------------------
+
+		let removeArrowSwitch = builder.get_object('remove_arrow_switch');
+		removeArrowSwitch.set_state(SETTINGS.get_boolean('remove-arrow'));
+
+		removeArrowSwitch.connect('notify::active', widget => {
+			if (widget.active) {
+				SETTINGS.set_boolean('remove-arrow', true);
+			} else {
+				SETTINGS.set_boolean('remove-arrow', false);
+			}
+		});
+
+		SETTINGS.connect('changed::remove-arrow', () => {
+			removeArrowSwitch.set_state(SETTINGS.get_boolean('remove-arrow'));
+		});
 	},
 
 	//--------------------------------------------------------------------------

--- a/emoji-selector@maestroschan.fr/prefs.ui
+++ b/emoji-selector@maestroschan.fr/prefs.ui
@@ -214,6 +214,44 @@
               </packing>
             </child>
 
+            <child>
+              <object class="GtkLabel">
+                <property name="expand">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Remove arrow on icon</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">18</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="remove_arrow_switch">
+                <property name="expand">False</property>
+                <property name="halign">start</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">18</property>
+              </packing>
+            </child>
+
+            <child>
+              <object class="GtkLabel">
+                <property name="expand">False</property>
+                <property name="wrap">True</property>
+                <property name="halign">center</property>
+                <property name="label" translatable="yes">This options requires a restart to take effect.</property>
+                <style><class name="dim-label"/></style>
+                <property name="max-width-chars">45</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="width">2</property>
+                <property name="top-attach">19</property>
+              </packing>
+            </child>
+
           </object>
         </child>
       </object>

--- a/emoji-selector@maestroschan.fr/schemas/org.gnome.shell.extensions.emoji-selector.gschema.xml
+++ b/emoji-selector@maestroschan.fr/schemas/org.gnome.shell.extensions.emoji-selector.gschema.xml
@@ -35,6 +35,11 @@
       <summary>if icon should always be shown</summary>
       <description>if false, Super+E will be the only way to display the popup menu.</description>
     </key>
+    <key type="b" name="remove-arrow">
+      <default>false</default>
+      <summary>if arrow should be removed from beside icon</summary>
+      <description>if true, the arrow will be removed from beside the tray icon.</description>
+    </key>
     <key type="i" name="skin-tone">
       <default>0</default>
       <summary>Favorite skin tone</summary>


### PR DESCRIPTION
As the title says, this PR adds an option to remove the arrow from the tray icon.  Disabled by default, requires the extension to be restarted to take effect.  Should be possible to do without a restart but I'm not familiar enough with Gnome extensions to do it, but will happily add the code to the PR if someone points me in the right direction.