### PR TITLE
Emoji hover background is barely visible

### DIFF
--- a/emoji-selector@maestroschan.fr/stylesheet.css
+++ b/emoji-selector@maestroschan.fr/stylesheet.css
@@ -29,7 +29,7 @@
 }
 
 .EmojisItemStyle:hover, .EmojisItemStyle:focus {
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(120, 120, 120, 1.0);
     border-radius: 6px;
 }
 


### PR DESCRIPTION
The background of hover interaction on the emojis is barely visible on dark theme. 
Used a more convenient color.