### PR TITLE
Update versions to include GNOME 40 and 41. Tested with Fedora 35

### DIFF
--- a/emoji-selector@maestroschan.fr/metadata.json
+++ b/emoji-selector@maestroschan.fr/metadata.json
@@ -2,9 +2,18 @@
 	"description": "This extension provides a parametrable popup menu displaying most emojis, clicking on an emoji copies it to the clipboard. An appropriate font like 'Twitter Color Emoji' or 'JoyPixels Color' should be installed on your system for a better visual result.",
 	"name": "Emoji Selector",
 	"shell-version": [
+		"3.26",
+		"3.28",
+		"3.30",
+		"3.32",
 		"3.34",
 		"3.36",
-		"3.38"
+		"3.38",
+		"3.49",
+		"40.0",
+		"41.0",
+		"41.1",
+		"41.2"
 	],
 	"url": "https://github.com/maoschanz/emoji-selector-for-gnome",
 	"uuid": "emoji-selector@maestroschan.fr",


### PR DESCRIPTION
This merge request allows the extension to work with GNOME 40 and 41 . It simply adds those versions to the **shell-version** list in **metadata.json** It has been tested working on Fedora 35
