### PR TITLE
Add support for auto pasting emoji upon selection

### DIFF
--- a/emoji-selector@maestroschan.fr/prefs.js
+++ b/emoji-selector@maestroschan.fr/prefs.js
@@ -65,6 +65,23 @@ const EmojiSelectorSettingsWidget = new GObject.Class({
 
 		//----------------------------------------------------------------------
 
+		let pasteonselectSwitch = builder.get_object('pasteonselect_switch');
+		pasteonselectSwitch.set_state(SETTINGS.get_boolean('paste-on-select'));
+
+		pasteonselectSwitch.connect('notify::active', widget => {
+			if (widget.active) {
+				SETTINGS.set_boolean('paste-on-select', true);
+			} else {
+				SETTINGS.set_boolean('paste-on-select', false);
+			}
+		});
+
+		SETTINGS.connect('changed::paste-on-select', () => {
+			pasteonselectSwitch.set_state(SETTINGS.get_boolean('paste-on-select'));
+		});
+
+		//----------------------------------------------------------------------
+
 		let nbColsSpinBtn = builder.get_object('nbcols_spinbtn');
 		nbColsSpinBtn.set_value(SETTINGS.get_int('nbcols'));
 		nbColsSpinBtn.connect('value-changed', w => {

--- a/emoji-selector@maestroschan.fr/prefs.ui
+++ b/emoji-selector@maestroschan.fr/prefs.ui
@@ -139,6 +139,42 @@
               </object>
             </child>
 
+               <child>
+              <object class="GtkListBoxRow">
+                <child>
+                  <object class="GtkBox">
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">12</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="spacing">32</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="halign">end</property>
+                            <property name="hexpand">False</property>
+                            <property name="vexpand">False</property>
+                            <property name="label" translatable="yes">*EXPERIMENTAL* Paste upon selection of emoji</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="pasteonselect_switch">
+                            <property name="can-focus">True</property>
+                            <property name="halign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">False</property>
+                            <property name="halign">end</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+
           </object>
         </child>
       </object>

--- a/emoji-selector@maestroschan.fr/schemas/org.gnome.shell.extensions.emoji-selector.gschema.xml
+++ b/emoji-selector@maestroschan.fr/schemas/org.gnome.shell.extensions.emoji-selector.gschema.xml
@@ -25,6 +25,11 @@
       <summary>default memorized emojis</summary>
       <description></description>
     </key>
+    <key type="b" name="paste-on-select">
+      <default>true</default>
+      <summary>if paste on select is enabled</summary>
+      <description>(EXPERIMENTAL) if true, Selecting an emoji will attempt to paste it on the focused textfield</description>
+    </key>
     <key type="b" name="use-keybinding">
       <default>true</default>
       <summary>if keybinding is enabled</summary>


### PR DESCRIPTION
This code is taken from:
https://github.com/SUPERCILEX/gnome-clipboard-history/blob/master/extension.js
Tested on my system running Fedora38 GNOME44 and it works flawlessly 
![image](https://github.com/maoschanz/emoji-selector-for-gnome/assets/74397286/24c81463-cdbf-48e2-83d1-9a189bdf1874)
